### PR TITLE
Add tests which demonstrate re-registration issue

### DIFF
--- a/150_UnityRegistrationDifferences/README.md
+++ b/150_UnityRegistrationDifferences/README.md
@@ -13,3 +13,4 @@
 * There is no expected solution here. The purpose of this task is to provide
   a quick playground for testing registrations and perhaps provide an overview
   of various types of registrations and re-registrations.
+* Be aware of non-obvious behavior in the ```Test13()```.

--- a/150_UnityRegistrationDifferences/UnityRegistrationDifferencesTest.cs
+++ b/150_UnityRegistrationDifferences/UnityRegistrationDifferencesTest.cs
@@ -201,6 +201,47 @@ namespace UnityRegistrationDifferences
             Assert.IsInstanceOf<LocalService>(instance);
             Assert.IsInstanceOf<LocalService>(instance2);
         }
+
+
+        [Test]
+        public void Test13()
+        {
+            var container = new UnityContainer();
+            container.RegisterType<IService, RemoteService>();
+
+            container.RegisterType<IService>(new InjectionFactory(c => c.Resolve<LocalService>()));
+
+            var instance = container.Resolve<IService>();
+
+            // This is unexpected behavior
+            Assert.IsInstanceOf<RemoteService>(instance);
+        }
+
+        [Test]
+        public void Test14()
+        {
+            var container = new UnityContainer();
+            container.RegisterType<IService>(new InjectionFactory(c => c.Resolve<RemoteService>()));
+
+            container.RegisterType<IService>(new InjectionFactory(c => c.Resolve<LocalService>()));
+
+            var instance = container.Resolve<IService>();
+
+            Assert.IsInstanceOf<LocalService>(instance);
+        }
+
+        [Test]
+        public void Test15()
+        {
+            var container = new UnityContainer();
+            container.RegisterType<IService>(new InjectionFactory(c => c.Resolve<LocalService>()));
+
+            container.RegisterType<IService, LocalService>();
+
+            var instance = container.Resolve<IService>();
+
+            Assert.IsInstanceOf<LocalService>(instance);
+        }
     }
 
     public interface IService2


### PR DESCRIPTION
When using a type registration which is later overriden by an injection factory registration the override may not happen as expected (see ```Test13()`).
